### PR TITLE
Make Metal backend usable

### DIFF
--- a/engine/src/Honey/renderer/render_command.cpp
+++ b/engine/src/Honey/renderer/render_command.cpp
@@ -2,7 +2,14 @@
 #include "render_command.h"
 
 #include "platform/opengl/opengl_renderer_api.h"
+#if defined(HN_PLATFORM_MACOS)
+#include "platform/metal/metal_renderer_api.h"
+#endif
 
 namespace Honey {
+    #if defined(HN_PLATFORM_MACOS)
+    RendererAPI* RenderCommand::s_renderer_api = create_metal_renderer_api();
+    #else
     RendererAPI* RenderCommand::s_renderer_api = new OpenGLRendererAPI;
+    #endif
 }

--- a/engine/src/platform/macos/macos_window.cpp
+++ b/engine/src/platform/macos/macos_window.cpp
@@ -14,6 +14,10 @@
 #include <glad/glad.h>
 
 #include "platform/opengl/opengl_context.h"
+#include "platform/metal/metal_context.h"
+#include "platform/metal/metal_renderer_api.h"
+#include "Honey/renderer/render_command.h"
+#include "Honey/renderer/renderer_api.h"
 
 namespace Honey {
 
@@ -56,17 +60,25 @@ namespace Honey {
             s_glfw_initialized = true;
         }
 
-        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
-        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+        if (RendererAPI::get_api() == RendererAPI::API::metal) {
+            glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+        } else {
+            glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+        }
 
         m_window = glfwCreateWindow((int)props.width, (int)props.height, m_data.title.c_str(), nullptr, nullptr);
         HN_CORE_ASSERT(m_window, "GLFW window creation failed!");
 
-        glfwMakeContextCurrent(m_window);
-        m_context = new OpenGLContext(m_window);
+        if (RendererAPI::get_api() == RendererAPI::API::metal) {
+            m_context = new MetalContext(m_window);
+        } else {
+            glfwMakeContextCurrent(m_window);
+            m_context = new OpenGLContext(m_window);
+        }
         m_context->init();
 
         glfwSetWindowUserPointer(m_window, &m_data);

--- a/engine/src/platform/metal/metal_context.h
+++ b/engine/src/platform/metal/metal_context.h
@@ -19,6 +19,8 @@ namespace Honey {
         void init() override;
         void swap_buffers() override;
 
+        id<MTLDevice> device() const { return m_device; }
+
     private:
         void resize_drawable();
 

--- a/engine/src/platform/metal/metal_renderer_api.h
+++ b/engine/src/platform/metal/metal_renderer_api.h
@@ -45,4 +45,8 @@ namespace Honey {
         glm::vec4                   m_clear    {0.f, 0.f, 0.f, 1.f};
     };
 
+    /** Convenience helper that instantiates a MetalRendererAPI using the
+     *  system default device.  Defined in metal_renderer_api.mm. */
+    RendererAPI* create_metal_renderer_api();
+
 } // namespace Honey

--- a/engine/src/platform/metal/metal_renderer_api.mm
+++ b/engine/src/platform/metal/metal_renderer_api.mm
@@ -136,3 +136,8 @@ void MetalRendererAPI::set_depth_test(bool)  { HN_CORE_ASSERT(false, "Swap pipel
 void MetalRendererAPI::set_blend(bool)       { HN_CORE_ASSERT(false, "Swap pipeline!"); }
 
 } // namespace Honey
+
+RendererAPI* Honey::create_metal_renderer_api() {
+    id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
+    return new MetalRendererAPI(dev);
+}


### PR DESCRIPTION
## Summary
- integrate Metal renderer with window system and rendering commands
- allow MacOS window to use Metal context
- provide factory for creating MetalRendererAPI

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687b0d6dea408329956f41509baa4e51